### PR TITLE
Including Variable Defaults

### DIFF
--- a/variables.hcl
+++ b/variables.hcl
@@ -1,6 +1,7 @@
 variable "subscription_id" {
   type        = string
   description = "Azure Subscription Id. Examples: d46d7416-f95f-4771-bbb5-529d4c766."
+  default = ""
   # TODO: Add once supported
   #sensitive  = true
 }
@@ -8,6 +9,7 @@ variable "subscription_id" {
 variable "resource_group" {
   type        = string
   description = "Azure Resource Group. Examples: my_resource_group."
+  default = ""
   # TODO: Add once supported
   #sensitive  = true
 }
@@ -15,6 +17,7 @@ variable "resource_group" {
 variable "tenant_id" {
   type        = string
   description = "The Microsoft Entra ID tenant (directory) ID."
+  default = ""
   # TODO: Add once supported
   #sensitive  = true
 }
@@ -22,6 +25,7 @@ variable "tenant_id" {
 variable "client_secret" {
   type        = string
   description = "A client secret that was generated for the App Registration."
+  default = ""
   # TODO: Add once supported
   #sensitive  = true
 }
@@ -29,6 +33,7 @@ variable "client_secret" {
 variable "client_id" {
   type        = string
   description = "The client (application) ID of an App Registration in the tenant."
+  default = ""
   # TODO: Add once supported
   #sensitive  = true
 }


### PR DESCRIPTION
- Without the `default = ""`, you can't use the library pipelines.